### PR TITLE
Persist cart selections across sessions

### DIFF
--- a/Sale/api_products.json
+++ b/Sale/api_products.json
@@ -1,0 +1,262 @@
+[
+  {
+    "id": 1,
+    "title": "Fjallraven - Foldsack No. 1 Backpack, Fits 15 Laptops",
+    "price": 109.95,
+    "description": "Your perfect pack for everyday use and walks in the forest. Stash your laptop (up to 15 inches) in the padded sleeve, your everyday",
+    "category": "men's clothing",
+    "image": "https://fakestoreapi.com/img/81fPKd-2AYL._AC_SL1500_t.png",
+    "rating": {
+      "rate": 3.9,
+      "count": 120
+    },
+    "inventory": 17
+  },
+  {
+    "id": 2,
+    "title": "Mens Casual Premium Slim Fit T-Shirts ",
+    "price": 22.3,
+    "description": "Slim-fitting style, contrast raglan long sleeve, three-button henley placket, light weight & soft fabric for breathable and comfortable wearing. And Solid stitched shirts with round neck made for durability and a great fit for casual fashion wear and diehard baseball fans. The Henley style round neckline includes a three-button placket.",
+    "category": "men's clothing",
+    "image": "https://fakestoreapi.com/img/71-3HjGNDUL._AC_SY879._SX._UX._SY._UY_t.png",
+    "rating": {
+      "rate": 4.1,
+      "count": 259
+    },
+    "inventory": 35
+  },
+  {
+    "id": 3,
+    "title": "Mens Cotton Jacket",
+    "price": 55.99,
+    "description": "great outerwear jackets for Spring/Autumn/Winter, suitable for many occasions, such as working, hiking, camping, mountain/rock climbing, cycling, traveling or other outdoors. Good gift choice for you or your family member. A warm hearted love to Father, husband or son in this thanksgiving or Christmas Day.",
+    "category": "men's clothing",
+    "image": "https://fakestoreapi.com/img/71li-ujtlUL._AC_UX679_t.png",
+    "rating": {
+      "rate": 4.7,
+      "count": 500
+    },
+    "inventory": 14
+  },
+  {
+    "id": 4,
+    "title": "Mens Casual Slim Fit",
+    "price": 15.99,
+    "description": "The color could be slightly different between on the screen and in practice. / Please note that body builds vary by person, therefore, detailed size information should be reviewed below on the product description.",
+    "category": "men's clothing",
+    "image": "https://fakestoreapi.com/img/71YXzeOuslL._AC_UY879_t.png",
+    "rating": {
+      "rate": 2.1,
+      "count": 430
+    },
+    "inventory": 6
+  },
+  {
+    "id": 5,
+    "title": "John Hardy Women's Legends Naga Gold & Silver Dragon Station Chain Bracelet",
+    "price": 695,
+    "description": "From our Legends Collection, the Naga was inspired by the mythical water dragon that protects the ocean's pearl. Wear facing inward to be bestowed with love and abundance, or outward for protection.",
+    "category": "jewelery",
+    "image": "https://fakestoreapi.com/img/71pWzhdJNwL._AC_UL640_QL65_ML3_t.png",
+    "rating": {
+      "rate": 4.6,
+      "count": 400
+    },
+    "inventory": 47
+  },
+  {
+    "id": 6,
+    "title": "Solid Gold Petite Micropave ",
+    "price": 168,
+    "description": "Satisfaction Guaranteed. Return or exchange any order within 30 days.Designed and sold by Hafeez Center in the United States. Satisfaction Guaranteed. Return or exchange any order within 30 days.",
+    "category": "jewelery",
+    "image": "https://fakestoreapi.com/img/61sbMiUnoGL._AC_UL640_QL65_ML3_t.png",
+    "rating": {
+      "rate": 3.9,
+      "count": 70
+    },
+    "inventory": 19
+  },
+  {
+    "id": 7,
+    "title": "White Gold Plated Princess",
+    "price": 9.99,
+    "description": "Classic Created Wedding Engagement Solitaire Diamond Promise Ring for Her. Gifts to spoil your love more for Engagement, Wedding, Anniversary, Valentine's Day...",
+    "category": "jewelery",
+    "image": "https://fakestoreapi.com/img/71YAIFU48IL._AC_UL640_QL65_ML3_t.png",
+    "rating": {
+      "rate": 3,
+      "count": 400
+    },
+    "inventory": 35
+  },
+  {
+    "id": 8,
+    "title": "Pierced Owl Rose Gold Plated Stainless Steel Double",
+    "price": 10.99,
+    "description": "Rose Gold Plated Double Flared Tunnel Plug Earrings. Made of 316L Stainless Steel",
+    "category": "jewelery",
+    "image": "https://fakestoreapi.com/img/51UDEzMJVpL._AC_UL640_QL65_ML3_t.png",
+    "rating": {
+      "rate": 1.9,
+      "count": 100
+    },
+    "inventory": 10
+  },
+  {
+    "id": 9,
+    "title": "WD 2TB Elements Portable External Hard Drive - USB 3.0 ",
+    "price": 64,
+    "description": "USB 3.0 and USB 2.0 Compatibility Fast data transfers Improve PC Performance High Capacity; Compatibility Formatted NTFS for Windows 10, Windows 8.1, Windows 7; Reformatting may be required for other operating systems; Compatibility may vary depending on user\u2019s hardware configuration and operating system",
+    "category": "electronics",
+    "image": "https://fakestoreapi.com/img/61IBBVJvSDL._AC_SY879_t.png",
+    "rating": {
+      "rate": 3.3,
+      "count": 203
+    },
+    "inventory": 22
+  },
+  {
+    "id": 10,
+    "title": "SanDisk SSD PLUS 1TB Internal SSD - SATA III 6 Gb/s",
+    "price": 109,
+    "description": "Easy upgrade for faster boot up, shutdown, application load and response (As compared to 5400 RPM SATA 2.5\u201d hard drive; Based on published specifications and internal benchmarking tests using PCMark vantage scores) Boosts burst write performance, making it ideal for typical PC workloads The perfect balance of performance and reliability Read/write speeds of up to 535MB/s/450MB/s (Based on internal testing; Performance may vary depending upon drive capacity, host device, OS and application.)",
+    "category": "electronics",
+    "image": "https://fakestoreapi.com/img/61U7T1koQqL._AC_SX679_t.png",
+    "rating": {
+      "rate": 2.9,
+      "count": 470
+    },
+    "inventory": 16
+  },
+  {
+    "id": 11,
+    "title": "Silicon Power 256GB SSD 3D NAND A55 SLC Cache Performance Boost SATA III 2.5",
+    "price": 109,
+    "description": "3D NAND flash are applied to deliver high transfer speeds Remarkable transfer speeds that enable faster bootup and improved overall system performance. The advanced SLC Cache Technology allows performance boost and longer lifespan 7mm slim design suitable for Ultrabooks and Ultra-slim notebooks. Supports TRIM command, Garbage Collection technology, RAID, and ECC (Error Checking & Correction) to provide the optimized performance and enhanced reliability.",
+    "category": "electronics",
+    "image": "https://fakestoreapi.com/img/71kWymZ+c+L._AC_SX679_t.png",
+    "rating": {
+      "rate": 4.8,
+      "count": 319
+    },
+    "inventory": 14
+  },
+  {
+    "id": 12,
+    "title": "WD 4TB Gaming Drive Works with Playstation 4 Portable External Hard Drive",
+    "price": 114,
+    "description": "Expand your PS4 gaming experience, Play anywhere Fast and easy, setup Sleek design with high capacity, 3-year manufacturer's limited warranty",
+    "category": "electronics",
+    "image": "https://fakestoreapi.com/img/61mtL65D4cL._AC_SX679_t.png",
+    "rating": {
+      "rate": 4.8,
+      "count": 400
+    },
+    "inventory": 24
+  },
+  {
+    "id": 13,
+    "title": "Acer SB220Q bi 21.5 inches Full HD (1920 x 1080) IPS Ultra-Thin",
+    "price": 599,
+    "description": "21. 5 inches Full HD (1920 x 1080) widescreen IPS display And Radeon free Sync technology. No compatibility for VESA Mount Refresh Rate: 75Hz - Using HDMI port Zero-frame design | ultra-thin | 4ms response time | IPS panel Aspect ratio - 16: 9. Color Supported - 16. 7 million colors. Brightness - 250 nit Tilt angle -5 degree to 15 degree. Horizontal viewing angle-178 degree. Vertical viewing angle-178 degree 75 hertz",
+    "category": "electronics",
+    "image": "https://fakestoreapi.com/img/81QpkIctqPL._AC_SX679_t.png",
+    "rating": {
+      "rate": 2.9,
+      "count": 250
+    },
+    "inventory": 9
+  },
+  {
+    "id": 14,
+    "title": "Samsung 49-Inch CHG90 144Hz Curved Gaming Monitor (LC49HG90DMNXZA) \u2013 Super Ultrawide Screen QLED ",
+    "price": 999.99,
+    "description": "49 INCH SUPER ULTRAWIDE 32:9 CURVED GAMING MONITOR with dual 27 inch screen side by side QUANTUM DOT (QLED) TECHNOLOGY, HDR support and factory calibration provides stunningly realistic and accurate color and contrast 144HZ HIGH REFRESH RATE and 1ms ultra fast response time work to eliminate motion blur, ghosting, and reduce input lag",
+    "category": "electronics",
+    "image": "https://fakestoreapi.com/img/81Zt42ioCgL._AC_SX679_t.png",
+    "rating": {
+      "rate": 2.2,
+      "count": 140
+    },
+    "inventory": 29
+  },
+  {
+    "id": 15,
+    "title": "BIYLACLESEN Women's 3-in-1 Snowboard Jacket Winter Coats",
+    "price": 56.99,
+    "description": "Note:The Jackets is US standard size, Please choose size as your usual wear Material: 100% Polyester; Detachable Liner Fabric: Warm Fleece. Detachable Functional Liner: Skin Friendly, Lightweigt and Warm.Stand Collar Liner jacket, keep you warm in cold weather. Zippered Pockets: 2 Zippered Hand Pockets, 2 Zippered Pockets on Chest (enough to keep cards or keys)and 1 Hidden Pocket Inside.Zippered Hand Pockets and Hidden Pocket keep your things secure. Humanized Design: Adjustable and Detachable Hood and Adjustable cuff to prevent the wind and water,for a comfortable fit. 3 in 1 Detachable Design provide more convenience, you can separate the coat and inner as needed, or wear it together. It is suitable for different season and help you adapt to different climates",
+    "category": "women's clothing",
+    "image": "https://fakestoreapi.com/img/51Y5NI-I5jL._AC_UX679_t.png",
+    "rating": {
+      "rate": 2.6,
+      "count": 235
+    },
+    "inventory": 21
+  },
+  {
+    "id": 16,
+    "title": "Lock and Love Women's Removable Hooded Faux Leather Moto Biker Jacket",
+    "price": 29.95,
+    "description": "100% POLYURETHANE(shell) 100% POLYESTER(lining) 75% POLYESTER 25% COTTON (SWEATER), Faux leather material for style and comfort / 2 pockets of front, 2-For-One Hooded denim style faux leather jacket, Button detail on waist / Detail stitching at sides, HAND WASH ONLY / DO NOT BLEACH / LINE DRY / DO NOT IRON",
+    "category": "women's clothing",
+    "image": "https://fakestoreapi.com/img/81XH0e8fefL._AC_UY879_t.png",
+    "rating": {
+      "rate": 2.9,
+      "count": 340
+    },
+    "inventory": 37
+  },
+  {
+    "id": 17,
+    "title": "Rain Jacket Women Windbreaker Striped Climbing Raincoats",
+    "price": 39.99,
+    "description": "Lightweight perfet for trip or casual wear---Long sleeve with hooded, adjustable drawstring waist design. Button and zipper front closure raincoat, fully stripes Lined and The Raincoat has 2 side pockets are a good size to hold all kinds of things, it covers the hips, and the hood is generous but doesn't overdo it.Attached Cotton Lined Hood with Adjustable Drawstrings give it a real styled look.",
+    "category": "women's clothing",
+    "image": "https://fakestoreapi.com/img/71HblAHs5xL._AC_UY879_-2t.png",
+    "rating": {
+      "rate": 3.8,
+      "count": 679
+    },
+    "inventory": 12
+  },
+  {
+    "id": 18,
+    "title": "MBJ Women's Solid Short Sleeve Boat Neck V ",
+    "price": 9.85,
+    "description": "95% RAYON 5% SPANDEX, Made in USA or Imported, Do Not Bleach, Lightweight fabric with great stretch for comfort, Ribbed on sleeves and neckline / Double stitching on bottom hem",
+    "category": "women's clothing",
+    "image": "https://fakestoreapi.com/img/71z3kpMAYsL._AC_UY879_t.png",
+    "rating": {
+      "rate": 4.7,
+      "count": 130
+    },
+    "inventory": 35
+  },
+  {
+    "id": 19,
+    "title": "Opna Women's Short Sleeve Moisture",
+    "price": 7.95,
+    "description": "100% Polyester, Machine wash, 100% cationic polyester interlock, Machine Wash & Pre Shrunk for a Great Fit, Lightweight, roomy and highly breathable with moisture wicking fabric which helps to keep moisture away, Soft Lightweight Fabric with comfortable V-neck collar and a slimmer fit, delivers a sleek, more feminine silhouette and Added Comfort",
+    "category": "women's clothing",
+    "image": "https://fakestoreapi.com/img/51eg55uWmdL._AC_UX679_t.png",
+    "rating": {
+      "rate": 4.5,
+      "count": 146
+    },
+    "inventory": 28
+  },
+  {
+    "id": 20,
+    "title": "DANVOUY Womens T Shirt Casual Cotton Short",
+    "price": 12.99,
+    "description": "95%Cotton,5%Spandex, Features: Casual, Short Sleeve, Letter Print,V-Neck,Fashion Tees, The fabric is soft and has some stretch., Occasion: Casual/Office/Beach/School/Home/Street. Season: Spring,Summer,Autumn,Winter.",
+    "category": "women's clothing",
+    "image": "https://fakestoreapi.com/img/61pHAEJ4NML._AC_UX679_t.png",
+    "rating": {
+      "rate": 3.6,
+      "count": 145
+    },
+    "inventory": 32
+  }
+]

--- a/lib/features/cart/data/cart_persistence.dart
+++ b/lib/features/cart/data/cart_persistence.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _cartStorageKey = 'cart.items.v1';
+
+class PersistedCartLine {
+  final int productId;
+  final int quantity;
+
+  const PersistedCartLine({required this.productId, required this.quantity});
+
+  Map<String, dynamic> toJson() => {
+        'productId': productId,
+        'quantity': quantity,
+      };
+
+  factory PersistedCartLine.fromJson(Map<String, dynamic> json) {
+    final productId = json['productId'];
+    final quantity = json['quantity'];
+    if (productId is! num || quantity is! num) {
+      throw const FormatException('Invalid persisted cart line');
+    }
+    return PersistedCartLine(
+      productId: productId.toInt(),
+      quantity: quantity.toInt(),
+    );
+  }
+}
+
+Future<List<PersistedCartLine>> readPersistedCart() async {
+  final prefs = await SharedPreferences.getInstance();
+  final raw = prefs.getString(_cartStorageKey);
+  if (raw == null || raw.isEmpty) {
+    return const <PersistedCartLine>[];
+  }
+  try {
+    final decoded = jsonDecode(raw) as List<dynamic>;
+    return [
+      for (final entry in decoded)
+        if (entry is Map)
+          PersistedCartLine.fromJson(Map<String, dynamic>.from(entry as Map)),
+    ];
+  } on FormatException {
+    return const <PersistedCartLine>[];
+  } on Object {
+    return const <PersistedCartLine>[];
+  }
+}
+
+Future<void> writePersistedCart(List<PersistedCartLine> lines) async {
+  final prefs = await SharedPreferences.getInstance();
+  if (lines.isEmpty) {
+    await prefs.remove(_cartStorageKey);
+    return;
+  }
+  final payload = jsonEncode([
+    for (final line in lines) line.toJson(),
+  ]);
+  await prefs.setString(_cartStorageKey, payload);
+}
+
+Future<void> clearPersistedCart() => writePersistedCart(const <PersistedCartLine>[]);

--- a/lib/features/cart/data/cart_provider.dart
+++ b/lib/features/cart/data/cart_provider.dart
@@ -1,5 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../../../models/product.dart';
+import '../../home/data/products_inventory_provider.dart';
+import 'cart_persistence.dart';
 
 class CartItem {
   final Product product;
@@ -11,9 +16,78 @@ class CartItem {
 }
 
 class CartController extends StateNotifier<List<CartItem>> {
-  CartController() : super(const []);
+  CartController(this.ref) : super(const []) {
+    Future.microtask(_restoreCart);
+  }
 
-  void add(Product p, [int quantity = 1]) {
+  final Ref ref;
+
+  Future<void> _restoreCart() async {
+    try {
+      final persisted = await readPersistedCart();
+      if (persisted.isEmpty) {
+        return;
+      }
+
+      final inventoryNotifier = ref.read(productsInventoryProvider.notifier);
+      var products = [...await ref.read(productsInventoryProvider.future)];
+      final restoredItems = <CartItem>[];
+
+      for (final line in persisted) {
+        final index = products.indexWhere((element) => element.id == line.productId);
+        if (index == -1) {
+          continue;
+        }
+
+        final product = products[index];
+        final available = product.inventory;
+        if (available <= 0) {
+          continue;
+        }
+
+        final desired = line.quantity;
+        final quantity = desired <= 0
+            ? 0
+            : (desired > available ? available : desired);
+        if (quantity <= 0) {
+          continue;
+        }
+
+        final reserved = await inventoryNotifier.reserveInventory(product.id, quantity);
+        if (!reserved) {
+          continue;
+        }
+
+        restoredItems.add(CartItem(product, quantity));
+        products[index] = product.copyWith(inventory: available - quantity);
+      }
+
+      if (restoredItems.isEmpty) {
+        await clearPersistedCart();
+        return;
+      }
+
+      state = restoredItems;
+      await _persistCart();
+    } catch (_) {
+      await clearPersistedCart();
+    }
+  }
+
+  Future<void> _persistCart() async {
+    await writePersistedCart([
+      for (final item in state)
+        PersistedCartLine(productId: item.product.id, quantity: item.quantity),
+    ]);
+  }
+
+  Future<bool> add(Product p, [int quantity = 1]) async {
+    final inventoryNotifier = ref.read(productsInventoryProvider.notifier);
+    final reserved = await inventoryNotifier.reserveInventory(p.id, quantity);
+    if (!reserved) {
+      return false;
+    }
+
     final idx = state.indexWhere((e) => e.product.id == p.id);
     if (idx == -1) {
       state = [...state, CartItem(p, quantity)];
@@ -23,34 +97,56 @@ class CartController extends StateNotifier<List<CartItem>> {
       updated[idx] = item.copyWith(quantity: item.quantity + quantity);
       state = updated;
     }
+    await _persistCart();
+    return true;
   }
 
-  void remove(Product p) {
+  Future<void> remove(Product p) async {
+    final idx = state.indexWhere((e) => e.product.id == p.id);
+    if (idx == -1) {
+      return;
+    }
+    final item = state[idx];
+    await ref.read(productsInventoryProvider.notifier).releaseInventory(p.id, item.quantity);
     state = state.where((e) => e.product.id != p.id).toList();
+    await _persistCart();
   }
 
-  void decrement(Product p) {
+  Future<void> decrement(Product p) async {
     final idx = state.indexWhere((e) => e.product.id == p.id);
     if (idx == -1) return;
     final updated = [...state];
     final item = updated[idx];
     final q = item.quantity - 1;
+    await ref.read(productsInventoryProvider.notifier).releaseInventory(p.id, 1);
     if (q <= 0) {
       updated.removeAt(idx);
     } else {
       updated[idx] = item.copyWith(quantity: q);
     }
     state = updated;
+    await _persistCart();
   }
 
   double get total => state.fold(0.0, (sum, i) => sum + i.product.price * i.quantity);
 
-  void clear() {
+  Future<void> clear() async {
+    final notifier = ref.read(productsInventoryProvider.notifier);
+    for (final item in state) {
+      await notifier.releaseInventory(item.product.id, item.quantity);
+    }
     state = const [];
+    await clearPersistedCart();
+  }
+
+  Future<void> checkout() async {
+    await ref.read(productsInventoryProvider.notifier).persistInventoryToDisk();
+    state = const [];
+    await clearPersistedCart();
   }
 }
 
-final cartProvider = StateNotifierProvider<CartController, List<CartItem>>((ref) => CartController());
+final cartProvider = StateNotifierProvider<CartController, List<CartItem>>((ref) => CartController(ref));
 
 // Total count of items across all cart lines (sum of quantities)
 final cartCountProvider = Provider<int>((ref) {

--- a/lib/features/home/data/inventory_persistence_io.dart
+++ b/lib/features/home/data/inventory_persistence_io.dart
@@ -1,0 +1,6 @@
+import 'dart:io';
+
+Future<void> saveInventoryData(String data) async {
+  final file = File('Sale/api_products.json');
+  await file.writeAsString('$data\n');
+}

--- a/lib/features/home/data/inventory_persistence_stub.dart
+++ b/lib/features/home/data/inventory_persistence_stub.dart
@@ -1,0 +1,1 @@
+Future<void> saveInventoryData(String data) async {}

--- a/lib/features/home/data/products_inventory_provider.dart
+++ b/lib/features/home/data/products_inventory_provider.dart
@@ -1,25 +1,63 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fakestore_custom_ui/models/product.dart';
-import 'package:fakestore_custom_ui/features/home/data/products_provider.dart';
+
+import '../../../models/product.dart';
+import 'inventory_persistence_stub.dart'
+    if (dart.library.io) 'inventory_persistence_io.dart';
+import 'products_provider.dart';
 
 final productsInventoryProvider = AsyncNotifierProvider<ProductsInventoryController, List<Product>>(ProductsInventoryController.new);
 
 class ProductsInventoryController extends AsyncNotifier<List<Product>> {
+  Future<List<Product>> _currentProducts() async {
+    final existing = state.valueOrNull;
+    if (existing != null) {
+      return existing;
+    }
+    return await future;
+  }
+
   @override
   FutureOr<List<Product>> build() async {
     return ref.watch(productsProvider.future);
   }
 
-  void decreaseInventory(int productId, int quantity) async {
-    final products = await future;
-    state = AsyncData([
-      for (final product in products)
-        if (product.id == productId)
-          product.copyWith(inventory: product.inventory - quantity)
-        else
-          product,
+  Future<bool> reserveInventory(int productId, int quantity) async {
+    final products = await _currentProducts();
+    final updated = [...products];
+    final index = updated.indexWhere((element) => element.id == productId);
+    if (index == -1) {
+      return false;
+    }
+    final product = updated[index];
+    if (product.inventory < quantity) {
+      return false;
+    }
+    updated[index] = product.copyWith(inventory: product.inventory - quantity);
+    state = AsyncData(updated);
+    return true;
+  }
+
+  Future<void> releaseInventory(int productId, int quantity) async {
+    final products = await _currentProducts();
+    final updated = [...products];
+    final index = updated.indexWhere((element) => element.id == productId);
+    if (index == -1) {
+      return;
+    }
+    final product = updated[index];
+    updated[index] = product.copyWith(inventory: product.inventory + quantity);
+    state = AsyncData(updated);
+  }
+
+  Future<void> persistInventoryToDisk() async {
+    final products = await _currentProducts();
+    final encoder = const JsonEncoder.withIndent('  ');
+    final jsonString = encoder.convert([
+      for (final product in products) product.toJson(),
     ]);
+    await saveInventoryData(jsonString);
   }
 }

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -7,6 +7,11 @@ class ProductRating {
         rate: (json['rate'] as num).toDouble(),
         count: (json['count'] as num).toInt(),
       );
+
+  Map<String, dynamic> toJson() => {
+        'rate': rate,
+        'count': count,
+      };
 }
 
 class Product {
@@ -62,5 +67,16 @@ class Product {
       inventory: inventory ?? this.inventory,
     );
   }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'price': price,
+        'description': description,
+        'category': category,
+        'image': image,
+        'rating': rating.toJson(),
+        'inventory': inventory,
+      };
 }
 

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -59,10 +59,23 @@ class ProductCard extends ConsumerWidget {
             Padding(
               padding: const EdgeInsets.all(12.0),
               child: ElevatedButton(
-                onPressed: () {
-                  ref.read(cartProvider.notifier).add(product);
-                },
-                child: const Text('Add to Cart'),
+                onPressed: product.inventory > 0
+                    ? () async {
+                        final success = await ref.read(cartProvider.notifier).add(product);
+                        if (!context.mounted) return;
+                        final messenger = ScaffoldMessenger.of(context);
+                        messenger.showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              success
+                                  ? 'Added ${product.title} to cart'
+                                  : 'Only ${product.inventory} left in stock',
+                            ),
+                          ),
+                        );
+                      }
+                    : null,
+                child: Text(product.inventory > 0 ? 'Add to Cart' : 'Out of Stock'),
               ),
             ),
           ],


### PR DESCRIPTION
## Summary
- add a shared-preferences backed persistence layer for cart line items
- restore cart contents on startup while re-reserving inventory and keep the cache in sync with all cart mutations

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2595d2c24832980003fc3433c95d5