### PR TITLE
Fix local Sale images display

### DIFF
--- a/lib/features/cart/presentation/cart_screen.dart
+++ b/lib/features/cart/presentation/cart_screen.dart
@@ -1,10 +1,10 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/cart_provider.dart';
 import '../../home/data/products_inventory_provider.dart';
 import '../../../widgets/breadcrumbs.dart';
+import '../../../widgets/product_image.dart';
 
 class CartScreen extends ConsumerWidget {
   const CartScreen({super.key});
@@ -42,8 +42,8 @@ class CartScreen extends ConsumerWidget {
                         orElse: () => item.product.inventory,
                       );
                       return ListTile(
-                        leading: CachedNetworkImage(
-                          imageUrl: item.product.image,
+                        leading: ProductImage(
+                          image: item.product.image,
                           width: 50,
                           height: 50,
                           fit: BoxFit.contain,

--- a/lib/features/product_detail/presentation/product_detail_screen.dart
+++ b/lib/features/product_detail/presentation/product_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../../../models/product.dart';
 import '../../cart/data/cart_provider.dart';
 import '../../../widgets/breadcrumbs.dart';
+import '../../../widgets/product_image.dart';
 import '../../home/data/products_inventory_provider.dart';
 import '../../home/data/products_provider.dart';
 
@@ -195,8 +196,8 @@ class _DetailFront extends StatelessWidget {
                   child: Container(
                     color: Theme.of(context).colorScheme.surface,
                     child: Center(
-                      child: Image.network(
-                        p.image,
+                      child: ProductImage(
+                        image: p.image,
                         fit: BoxFit.contain,
                       ),
                     ),

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -1,9 +1,9 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/cart/data/cart_provider.dart';
 import '../models/product.dart';
+import 'product_image.dart';
 
 class ProductCard extends ConsumerWidget {
   final Product product;
@@ -20,11 +20,11 @@ class ProductCard extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Expanded(
-              child: CachedNetworkImage(
-                imageUrl: product.image,
+              child: ProductImage(
+                image: product.image,
                 fit: BoxFit.contain,
-                placeholder: (context, url) => const Center(child: CircularProgressIndicator()),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                placeholderBuilder: (context) => const Center(child: CircularProgressIndicator()),
+                errorBuilder: (context, error) => const Icon(Icons.error),
               ),
             ),
             Padding(

--- a/lib/widgets/product_image.dart
+++ b/lib/widgets/product_image.dart
@@ -1,0 +1,64 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+typedef ProductImagePlaceholderBuilder = Widget Function(BuildContext context);
+typedef ProductImageErrorBuilder = Widget Function(BuildContext context, Object error);
+
+class ProductImage extends StatelessWidget {
+  final String image;
+  final double? width;
+  final double? height;
+  final BoxFit fit;
+  final Alignment alignment;
+  final ProductImagePlaceholderBuilder? placeholderBuilder;
+  final ProductImageErrorBuilder? errorBuilder;
+
+  const ProductImage({
+    super.key,
+    required this.image,
+    this.width,
+    this.height,
+    this.fit = BoxFit.cover,
+    this.alignment = Alignment.center,
+    this.placeholderBuilder,
+    this.errorBuilder,
+  });
+
+  bool get _isRemote => image.startsWith('http');
+
+  String get _assetPath {
+    if (image.startsWith('assets/') || image.startsWith('Sale/')) {
+      return image;
+    }
+    if (image.startsWith('/')) {
+      return 'Sale/${image.substring(1)}';
+    }
+    return 'Sale/$image';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isRemote) {
+      return CachedNetworkImage(
+        imageUrl: image,
+        width: width,
+        height: height,
+        fit: fit,
+        alignment: alignment,
+        placeholder: placeholderBuilder != null ? (context, _) => placeholderBuilder!(context) : null,
+        errorWidget: (context, _, error) =>
+            errorBuilder != null ? errorBuilder!(context, error) : const Icon(Icons.error),
+      );
+    }
+
+    return Image.asset(
+      _assetPath,
+      width: width,
+      height: height,
+      fit: fit,
+      alignment: alignment,
+      errorBuilder: (context, error, stackTrace) =>
+          errorBuilder != null ? errorBuilder!(context, error) : const Icon(Icons.error),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared ProductImage widget that resolves Sale asset paths and falls back to network loading
- update product card, cart list, and product detail views to use the shared widget so Sale images render correctly

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e265c9dd6083299664345a2f0248ab