### PR TITLE
Add offcanvas cart drawer to home screen

### DIFF
--- a/lib/features/cart/presentation/cart_screen.dart
+++ b/lib/features/cart/presentation/cart_screen.dart
@@ -11,86 +11,122 @@ class CartScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    return const Scaffold(
+      appBar: AppBar(
+        title: Text('Your Cart'),
+      ),
+      body: CartContents(),
+    );
+  }
+}
+
+class CartContents extends ConsumerWidget {
+  final bool showBreadcrumbs;
+  final VoidCallback? onClose;
+
+  const CartContents({super.key, this.showBreadcrumbs = true, this.onClose});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final cartItems = ref.watch(cartProvider);
     final cartNotifier = ref.read(cartProvider.notifier);
     final inventoryState = ref.watch(productsInventoryProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Your Cart'),
-      ),
-      body: Column(
-        children: [
+    final closeAction = onClose ?? () => Navigator.of(context).maybePop();
+
+    return Column(
+      children: [
+        if (showBreadcrumbs)
           Breadcrumbs(
-            items: [
+            items: const [
               BreadcrumbItem(title: 'Home', path: '/'),
               BreadcrumbItem(title: 'Cart', path: '/cart'),
             ],
-          ),
-          Expanded(
-            child: cartItems.isEmpty
-                ? const Center(
-                    child: Text('Your cart is empty.'),
-                  )
-                : ListView.builder(
-                    itemCount: cartItems.length,
-                    itemBuilder: (context, index) {
-                      final item = cartItems[index];
-                      final available = inventoryState.maybeWhen(
-                        data: (products) =>
-                            products.firstWhere((element) => element.id == item.product.id, orElse: () => item.product).inventory,
-                        orElse: () => item.product.inventory,
-                      );
-                      return ListTile(
-                        leading: ProductImage(
-                          image: item.product.image,
-                          width: 50,
-                          height: 50,
-                          fit: BoxFit.contain,
-                        ),
-                        title: Text(item.product.title),
-                        subtitle: Text('\$${item.product.price.toStringAsFixed(2)}'),
-                        trailing: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            IconButton(
-                              icon: const Icon(Icons.remove),
-                              onPressed: () async {
-                                await cartNotifier.decrement(item.product);
-                              },
-                            ),
-                            Text(item.quantity.toString()),
-                            IconButton(
-                              icon: const Icon(Icons.add),
-                              onPressed: () async {
-                                final added = await cartNotifier.add(item.product);
-                                if (!added && context.mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(content: Text('Only $available left in stock.')),
-                                  );
-                                }
-                              },
-                            ),
-                            IconButton(
-                              icon: const Icon(Icons.delete),
-                              onPressed: () async {
-                                await cartNotifier.remove(item.product);
-                              },
-                            ),
-                          ],
-                        ),
-                      );
-                    },
+          )
+        else
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Your Cart',
+                    style: Theme.of(context).textTheme.titleLarge,
                   ),
+                ),
+                IconButton(
+                  tooltip: 'Close cart',
+                  onPressed: closeAction,
+                  icon: const Icon(Icons.close),
+                ),
+              ],
+            ),
           ),
-          if (cartItems.isNotEmpty) _CartTotals(),
-        ],
-      ),
+        Expanded(
+          child: cartItems.isEmpty
+              ? const Center(
+                  child: Text('Your cart is empty.'),
+                )
+              : ListView.builder(
+                  itemCount: cartItems.length,
+                  itemBuilder: (context, index) {
+                    final item = cartItems[index];
+                    final available = inventoryState.maybeWhen(
+                      data: (products) =>
+                          products.firstWhere((element) => element.id == item.product.id, orElse: () => item.product).inventory,
+                      orElse: () => item.product.inventory,
+                    );
+                    return ListTile(
+                      leading: ProductImage(
+                        image: item.product.image,
+                        width: 50,
+                        height: 50,
+                        fit: BoxFit.contain,
+                      ),
+                      title: Text(item.product.title),
+                      subtitle: Text('\$${item.product.price.toStringAsFixed(2)}'),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.remove),
+                            onPressed: () async {
+                              await cartNotifier.decrement(item.product);
+                            },
+                          ),
+                          Text(item.quantity.toString()),
+                          IconButton(
+                            icon: const Icon(Icons.add),
+                            onPressed: () async {
+                              final added = await cartNotifier.add(item.product);
+                              if (!added && context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text('Only $available left in stock.')),
+                                );
+                              }
+                            },
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () async {
+                              await cartNotifier.remove(item.product);
+                            },
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+        ),
+        if (cartItems.isNotEmpty) const _CartTotals(),
+      ],
     );
   }
 }
 
 class _CartTotals extends ConsumerWidget {
+  const _CartTotals({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final total = ref.watch(cartProvider.notifier).total;

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -3,20 +3,37 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../cart/data/cart_provider.dart';
+import '../../cart/presentation/cart_screen.dart';
 import '../data/products_inventory_provider.dart';
 import '../data/products_provider.dart';
 import '../../../widgets/product_card.dart';
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  void _openCartDrawer() {
+    _scaffoldKey.currentState?.openEndDrawer();
+  }
+
+  void _closeCartDrawer() {
+    _scaffoldKey.currentState?.closeEndDrawer();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final productsAsync = ref.watch(productsInventoryProvider);
     final categoriesAsync = ref.watch(categoriesProvider);
     final selected = ref.watch(selectedCategoryProvider);
 
     return Scaffold(
+      key: _scaffoldKey,
       appBar: AppBar(
         title: const Text('POS System'),
         actions: [
@@ -27,7 +44,7 @@ class HomeScreen extends ConsumerWidget {
                 children: [
                   IconButton(
                     tooltip: 'Cart',
-                    onPressed: () => context.go('/cart'),
+                    onPressed: _openCartDrawer,
                     icon: const Icon(Icons.shopping_cart),
                   ),
                   if (count > 0)
@@ -51,6 +68,16 @@ class HomeScreen extends ConsumerWidget {
             },
           ),
         ],
+      ),
+      endDrawerEnableOpenDragGesture: false,
+      endDrawer: Drawer(
+        width: 420,
+        child: SafeArea(
+          child: CartContents(
+            showBreadcrumbs: false,
+            onClose: _closeCartDrawer,
+          ),
+        ),
       ),
       body: Column(
         children: [


### PR DESCRIPTION
## Summary
- convert the home screen to a stateful widget with an end drawer that exposes the cart as an off-canvas panel
- extract a reusable cart contents widget so the drawer and cart screen share the same layout

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e26ca721c48329b0ff5fdcf1b3fef3