### PR TITLE
Prompt for phone number before Daraja checkout

### DIFF
--- a/lib/features/cart/data/cart_provider.dart
+++ b/lib/features/cart/data/cart_provider.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../models/product.dart';
+import '../../../services/daraja_service.dart';
+import '../../../services/providers.dart';
 import '../../home/data/products_inventory_provider.dart';
 import 'cart_persistence.dart';
 
@@ -139,10 +141,22 @@ class CartController extends StateNotifier<List<CartItem>> {
     await clearPersistedCart();
   }
 
-  Future<void> checkout() async {
+  Future<DarajaReceipt> checkout({String? phoneNumber}) async {
+    if (state.isEmpty) {
+      throw DarajaException('Cart is empty.');
+    }
+
+    final total = this.total;
+    final darajaService = ref.read(darajaServiceProvider);
+    final receipt = await darajaService.initiateStkPush(
+      amount: total,
+      phoneNumber: phoneNumber,
+    );
+
     await ref.read(productsInventoryProvider.notifier).persistInventoryToDisk();
     state = const [];
     await clearPersistedCart();
+    return receipt;
   }
 }
 

--- a/lib/features/cart/presentation/cart_screen.dart
+++ b/lib/features/cart/presentation/cart_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/cart_provider.dart';
 import '../../home/data/products_inventory_provider.dart';
+import '../../../services/daraja_service.dart';
+import '../../../services/providers.dart';
 import '../../../widgets/breadcrumbs.dart';
 import '../../../widgets/product_image.dart';
 
@@ -11,88 +13,144 @@ class CartScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Your Cart'),
+      ),
+      body: const CartContents(),
+    );
+  }
+}
+
+class CartContents extends ConsumerWidget {
+  final bool showBreadcrumbs;
+  final VoidCallback? onClose;
+
+  const CartContents({super.key, this.showBreadcrumbs = true, this.onClose});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final cartItems = ref.watch(cartProvider);
     final cartNotifier = ref.read(cartProvider.notifier);
     final inventoryState = ref.watch(productsInventoryProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Your Cart'),
-      ),
-      body: Column(
-        children: [
+    final closeAction = onClose ?? () => Navigator.of(context).maybePop();
+
+    return Column(
+      children: [
+        if (showBreadcrumbs)
           Breadcrumbs(
             items: [
               BreadcrumbItem(title: 'Home', path: '/'),
               BreadcrumbItem(title: 'Cart', path: '/cart'),
             ],
-          ),
-          Expanded(
-            child: cartItems.isEmpty
-                ? const Center(
-                    child: Text('Your cart is empty.'),
-                  )
-                : ListView.builder(
-                    itemCount: cartItems.length,
-                    itemBuilder: (context, index) {
-                      final item = cartItems[index];
-                      final available = inventoryState.maybeWhen(
-                        data: (products) =>
-                            products.firstWhere((element) => element.id == item.product.id, orElse: () => item.product).inventory,
-                        orElse: () => item.product.inventory,
-                      );
-                      return ListTile(
-                        leading: ProductImage(
-                          image: item.product.image,
-                          width: 50,
-                          height: 50,
-                          fit: BoxFit.contain,
-                        ),
-                        title: Text(item.product.title),
-                        subtitle: Text('\$${item.product.price.toStringAsFixed(2)}'),
-                        trailing: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            IconButton(
-                              icon: const Icon(Icons.remove),
-                              onPressed: () async {
-                                await cartNotifier.decrement(item.product);
-                              },
-                            ),
-                            Text(item.quantity.toString()),
-                            IconButton(
-                              icon: const Icon(Icons.add),
-                              onPressed: () async {
-                                final added = await cartNotifier.add(item.product);
-                                if (!added && context.mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(content: Text('Only $available left in stock.')),
-                                  );
-                                }
-                              },
-                            ),
-                            IconButton(
-                              icon: const Icon(Icons.delete),
-                              onPressed: () async {
-                                await cartNotifier.remove(item.product);
-                              },
-                            ),
-                          ],
-                        ),
-                      );
-                    },
+          )
+        else
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Your Cart',
+                    style: Theme.of(context).textTheme.titleLarge,
                   ),
+                ),
+                IconButton(
+                  tooltip: 'Close cart',
+                  onPressed: closeAction,
+                  icon: const Icon(Icons.close),
+                ),
+              ],
+            ),
           ),
-          if (cartItems.isNotEmpty) _CartTotals(),
-        ],
-      ),
+        Expanded(
+          child: cartItems.isEmpty
+              ? const Center(
+                  child: Text('Your cart is empty.'),
+                )
+              : ListView.builder(
+                  itemCount: cartItems.length,
+                  itemBuilder: (context, index) {
+                    final item = cartItems[index];
+                    final available = inventoryState.maybeWhen(
+                      data: (products) =>
+                          products.firstWhere((element) => element.id == item.product.id, orElse: () => item.product).inventory,
+                      orElse: () => item.product.inventory,
+                    );
+                    return ListTile(
+                      leading: ProductImage(
+                        image: item.product.image,
+                        width: 50,
+                        height: 50,
+                        fit: BoxFit.contain,
+                      ),
+                      title: Text(item.product.title),
+                      subtitle: Text('\$${item.product.price.toStringAsFixed(2)}'),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.remove),
+                            onPressed: () async {
+                              await cartNotifier.decrement(item.product);
+                            },
+                          ),
+                          Text(item.quantity.toString()),
+                          IconButton(
+                            icon: const Icon(Icons.add),
+                            onPressed: () async {
+                              final added = await cartNotifier.add(item.product);
+                              if (!added && context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text('Only $available left in stock.')),
+                                );
+                              }
+                            },
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () async {
+                              await cartNotifier.remove(item.product);
+                            },
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+        ),
+        if (cartItems.isNotEmpty) const _CartTotals(),
+      ],
     );
   }
 }
 
-class _CartTotals extends ConsumerWidget {
+class _CartTotals extends ConsumerStatefulWidget {
+  const _CartTotals({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_CartTotals> createState() => _CartTotalsState();
+}
+
+class _CartTotalsState extends ConsumerState<_CartTotals> {
+  late final TextEditingController _phoneController;
+
+  @override
+  void initState() {
+    super.initState();
+    final config = ref.read(darajaConfigProvider);
+    _phoneController = TextEditingController(text: config.defaultMsisdn ?? '');
+  }
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final total = ref.watch(cartProvider.notifier).total;
     final tax = total * 0.1;
     final subtotal = total - tax;
@@ -137,13 +195,63 @@ class _CartTotals extends ConsumerWidget {
             ],
           ),
           const SizedBox(height: 16.0),
+          TextField(
+            controller: _phoneController,
+            keyboardType: TextInputType.phone,
+            decoration: const InputDecoration(
+              labelText: 'Phone Number',
+              hintText: 'Enter the phone number to be charged',
+              prefixIcon: Icon(Icons.phone),
+            ),
+          ),
+          const SizedBox(height: 16.0),
           ElevatedButton(
             onPressed: () async {
-              await ref.read(cartProvider.notifier).checkout();
-              if (context.mounted) {
+              final input = _phoneController.text.trim();
+              if (input.isEmpty) {
                 ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Checkout complete! Inventory updated.')),
+                  const SnackBar(content: Text('Please enter the phone number to continue.')),
                 );
+                return;
+              }
+
+              final navigator = Navigator.of(context, rootNavigator: true);
+              showDialog<void>(
+                context: context,
+                barrierDismissible: false,
+                builder: (_) => const Center(child: CircularProgressIndicator()),
+              );
+              try {
+                final receipt = await ref.read(cartProvider.notifier).checkout(
+                      phoneNumber: input,
+                    );
+                if (navigator.mounted) {
+                  navigator.pop();
+                }
+                if (context.mounted) {
+                  await showDialog<void>(
+                    context: context,
+                    builder: (_) => _ReceiptDialog(receipt: receipt),
+                  );
+                }
+              } on DarajaException catch (error) {
+                if (navigator.mounted) {
+                  navigator.pop();
+                }
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(error.message)),
+                  );
+                }
+              } catch (_) {
+                if (navigator.mounted) {
+                  navigator.pop();
+                }
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Checkout failed. Please try again.')),
+                  );
+                }
               }
             },
             child: const Text('Checkout'),
@@ -155,6 +263,67 @@ class _CartTotals extends ConsumerWidget {
             },
             child: const Text('Clear Cart'),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReceiptDialog extends StatelessWidget {
+  const _ReceiptDialog({required this.receipt});
+
+  final DarajaReceipt receipt;
+
+  String _formatDateTime(DateTime dateTime) {
+    final local = dateTime.toLocal();
+    final date = '${local.year.toString().padLeft(4, '0')}-${local.month.toString().padLeft(2, '0')}-${local.day.toString().padLeft(2, '0')}';
+    final time = '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}:${local.second.toString().padLeft(2, '0')}';
+    return '$date $time';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Payment Receipt'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _ReceiptRow(label: 'Amount', value: 'KES ${receipt.amount.toStringAsFixed(2)}'),
+          _ReceiptRow(label: 'Phone', value: receipt.phoneNumber),
+          _ReceiptRow(label: 'Merchant Request ID', value: receipt.merchantRequestId),
+          _ReceiptRow(label: 'Checkout Request ID', value: receipt.checkoutRequestId),
+          _ReceiptRow(label: 'Description', value: receipt.responseDescription),
+          _ReceiptRow(label: 'Timestamp', value: _formatDateTime(receipt.timestamp)),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+class _ReceiptRow extends StatelessWidget {
+  const _ReceiptRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: theme.labelSmall),
+          const SizedBox(height: 2),
+          Text(value, style: theme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),
         ],
       ),
     );

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -3,20 +3,37 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../cart/data/cart_provider.dart';
+import '../../cart/presentation/cart_screen.dart';
 import '../data/products_inventory_provider.dart';
 import '../data/products_provider.dart';
 import '../../../widgets/product_card.dart';
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  void _openCartDrawer() {
+    _scaffoldKey.currentState?.openEndDrawer();
+  }
+
+  void _closeCartDrawer() {
+    _scaffoldKey.currentState?.closeEndDrawer();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final productsAsync = ref.watch(productsInventoryProvider);
     final categoriesAsync = ref.watch(categoriesProvider);
     final selected = ref.watch(selectedCategoryProvider);
 
     return Scaffold(
+      key: _scaffoldKey,
       appBar: AppBar(
         title: const Text('POS System'),
         actions: [
@@ -27,7 +44,7 @@ class HomeScreen extends ConsumerWidget {
                 children: [
                   IconButton(
                     tooltip: 'Cart',
-                    onPressed: () => context.go('/cart'),
+                    onPressed: _openCartDrawer,
                     icon: const Icon(Icons.shopping_cart),
                   ),
                   if (count > 0)
@@ -51,6 +68,16 @@ class HomeScreen extends ConsumerWidget {
             },
           ),
         ],
+      ),
+      endDrawerEnableOpenDragGesture: false,
+      endDrawer: Drawer(
+        width: 420,
+        child: SafeArea(
+          child: CartContents(
+            showBreadcrumbs: false,
+            onClose: _closeCartDrawer,
+          ),
+        ),
       ),
       body: Column(
         children: [

--- a/lib/services/daraja_service.dart
+++ b/lib/services/daraja_service.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+/// Configuration needed to initiate a Daraja STK push payment.
+class DarajaConfig {
+  const DarajaConfig({
+    required this.businessShortCode,
+    required this.passkey,
+    required this.callbackUrl,
+    required this.bearerToken,
+    this.transactionType = 'CustomerPayBillOnline',
+    this.accountReference = 'CompanyXLTD',
+    this.transactionDescription = 'Payment of goods',
+    this.partyB,
+    this.defaultMsisdn,
+  });
+
+  final String businessShortCode;
+  final String passkey;
+  final String callbackUrl;
+  final String bearerToken;
+  final String transactionType;
+  final String accountReference;
+  final String transactionDescription;
+  final String? partyB;
+  final String? defaultMsisdn;
+}
+
+/// Exception thrown when the Daraja API indicates a failure.
+class DarajaException implements Exception {
+  DarajaException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'DarajaException: $message';
+}
+
+/// Simple receipt generated after a successful STK push initiation.
+class DarajaReceipt {
+  const DarajaReceipt({
+    required this.amount,
+    required this.phoneNumber,
+    required this.timestamp,
+    required this.merchantRequestId,
+    required this.checkoutRequestId,
+    required this.responseDescription,
+  });
+
+  final double amount;
+  final String phoneNumber;
+  final DateTime timestamp;
+  final String merchantRequestId;
+  final String checkoutRequestId;
+  final String responseDescription;
+}
+
+/// Handles communication with the Daraja STK push API.
+class DarajaService {
+  DarajaService({
+    Dio? dio,
+    required DarajaConfig config,
+  })  : _dio = dio ?? Dio(BaseOptions(baseUrl: 'https://sandbox.safaricom.co.ke/mpesa')),
+        _config = config;
+
+  final Dio _dio;
+  final DarajaConfig _config;
+
+  /// Initiates an STK push request using the configured Daraja credentials.
+  Future<DarajaReceipt> initiateStkPush({
+    required double amount,
+    String? phoneNumber,
+  }) async {
+    if (amount <= 0) {
+      throw DarajaException('Amount must be greater than zero.');
+    }
+
+    final payer = phoneNumber ?? _config.defaultMsisdn;
+    if (payer == null || payer.isEmpty) {
+      throw DarajaException('A phone number is required for payment.');
+    }
+
+    final sanitizedPayer = payer.replaceAll(RegExp(r'\D'), '');
+    if (sanitizedPayer.isEmpty) {
+      throw DarajaException('Phone number contains invalid characters.');
+    }
+
+    final timestamp = _generateTimestamp(DateTime.now().toUtc());
+    final password = base64Encode(utf8.encode('${_config.businessShortCode}${_config.passkey}$timestamp'));
+
+    final body = <String, dynamic>{
+      'BusinessShortCode': _config.businessShortCode,
+      'Password': password,
+      'Timestamp': timestamp,
+      'TransactionType': _config.transactionType,
+      'Amount': amount.round(),
+      'PartyA': sanitizedPayer,
+      'PartyB': _config.partyB ?? _config.businessShortCode,
+      'PhoneNumber': sanitizedPayer,
+      'CallBackURL': _config.callbackUrl,
+      'AccountReference': _config.accountReference,
+      'TransactionDesc': _config.transactionDescription,
+    };
+
+    try {
+      final response = await _dio.post<Map<String, dynamic>>(
+        '/stkpush/v1/processrequest',
+        data: body,
+        options: Options(
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ${_config.bearerToken}',
+          },
+        ),
+      );
+
+      final data = response.data ?? const <String, dynamic>{};
+      final responseCode = data['ResponseCode']?.toString();
+      if (responseCode != '0') {
+        final description = data['ResponseDescription']?.toString() ?? 'Unknown error';
+        throw DarajaException(description);
+      }
+
+      return DarajaReceipt(
+        amount: amount,
+        phoneNumber: sanitizedPayer,
+        timestamp: DateTime.now(),
+        merchantRequestId: data['MerchantRequestID']?.toString() ?? '',
+        checkoutRequestId: data['CheckoutRequestID']?.toString() ?? '',
+        responseDescription: data['ResponseDescription']?.toString() ?? '',
+      );
+    } on DioException catch (error) {
+      final isNetworkError = error.type == DioExceptionType.connectionError ||
+          (error.message?.toLowerCase().contains('xmlhttprequest') ?? false);
+
+      if (isNetworkError) {
+        throw DarajaException(
+          'Network error while contacting the payment service. Please check your internet connection and try again.',
+        );
+      }
+
+      final message = error.response?.data is Map<String, dynamic>
+          ? (error.response!.data['errorMessage']?.toString() ?? error.message)
+          : error.message;
+      throw DarajaException(message ?? 'Failed to initiate payment.');
+    }
+  }
+
+  String _generateTimestamp(DateTime dateTime) {
+    final y = dateTime.year.toString().padLeft(4, '0');
+    final m = dateTime.month.toString().padLeft(2, '0');
+    final d = dateTime.day.toString().padLeft(2, '0');
+    final h = dateTime.hour.toString().padLeft(2, '0');
+    final min = dateTime.minute.toString().padLeft(2, '0');
+    final s = dateTime.second.toString().padLeft(2, '0');
+    return '$y$m$d$h$min$s';
+  }
+}
+

--- a/lib/services/providers.dart
+++ b/lib/services/providers.dart
@@ -1,5 +1,25 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'api_service.dart';
+import 'daraja_service.dart';
 
 final apiServiceProvider = Provider<ApiService>((ref) => ApiService());
+
+final darajaConfigProvider = Provider<DarajaConfig>((ref) {
+  return const DarajaConfig(
+    businessShortCode: '174379',
+    passkey:
+        'bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f786b72ada1ed2c919',
+    callbackUrl: 'https://mydomain.com/path',
+    bearerToken: 'FsboV0UNFQgd4XPitzgNuAGzbl0Y',
+    accountReference: 'CompanyXLTD',
+    transactionDescription: 'Payment of X',
+    defaultMsisdn: '254799213371',
+    partyB: '174379',
+  );
+});
+
+final darajaServiceProvider = Provider<DarajaService>((ref) {
+  final config = ref.watch(darajaConfigProvider);
+  return DarajaService(config: config);
+});
 


### PR DESCRIPTION
## Summary
- request the customer's phone number in the cart checkout panel before initiating the Daraja STK push
- default the phone field from the configured Daraja settings and reuse it when generating the receipt
- surface a clearer network error message when the Daraja API call fails due to XMLHttpRequest issues

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e26ca721c48329b0ff5fdcf1b3fef3